### PR TITLE
Update to support Xcode 15.4, SwiftUI, add license

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore Xcode user data
+xcuserdata/

--- a/CGSKeyboardShortcut.swift
+++ b/CGSKeyboardShortcut.swift
@@ -1,4 +1,4 @@
-import Foundation
+import AppKit
 
 // The following imports are required for `CGKeyCode` extensions:
 import Carbon.HIToolbox.TextInputSources
@@ -270,25 +270,25 @@ extension CGEventFlags: Hashable, Codable {
 
 public extension CGEventFlags {
     /// Convert `NSEvent.ModifierFlags` into `CGEventFlags`.
-    public init(_ flags: NSEvent.ModifierFlags) {
+    init(_ flags: NSEvent.ModifierFlags) {
         self.init(rawValue: UInt64(flags.rawValue))
     }
     
     /// Used to retrieve only the device-independent modifier flags, allowing
     /// applications to mask off the device-dependent modifier flags, including
     /// event coalescing information.
-    public static let maskDeviceIndependentFlags = CGEventFlags(rawValue: 0x00000000ffff0000)
+    static let maskDeviceIndependentFlags = CGEventFlags(rawValue: 0x00000000ffff0000)
     
     /// Used to retrieve only the shortcut-usable modifier flags.
-    public static let maskShortcutFlags = CGEventFlags(rawValue: 0x0000000000ff0000)
+    static let maskShortcutFlags = CGEventFlags(rawValue: 0x0000000000ff0000)
     
     /// Used to retrieve only the user transient modifier flags (i.e. no caps-lock).
-    public static let maskUserFlags: CGEventFlags = [.maskCommand, .maskControl, .maskShift, .maskAlternate]
+    static let maskUserFlags: CGEventFlags = [.maskCommand, .maskControl, .maskShift, .maskAlternate]
 }
 
 public extension NSEvent.ModifierFlags {
     /// Convert `CGEventFlags` into `NSEvent.ModifierFlags`.
-    public init(_ flags: CGEventFlags) {
+    init(_ flags: CGEventFlags) {
         self.init(rawValue: UInt(flags.rawValue))
     }
 }
@@ -302,7 +302,7 @@ public extension NSEvent.ModifierFlags {
 public extension CGKeyCode {
     
     /// Is this virtual key code actually a function key?
-    public var isFunctionKey: Bool {
+    var isFunctionKey: Bool {
         switch Int(self) {
         // Virtual key constants are *NOT* sequential like ASCII.
         case kVK_F1, kVK_F2, kVK_F3, kVK_F4, kVK_F5, kVK_F6, kVK_F7, kVK_F8,
@@ -318,7 +318,7 @@ public extension CGKeyCode {
     ///
     /// Note: dead keys (dead key `´` is usually used to produce live key `é`)
     /// are not considered.
-    public var characters: String {
+    var characters: String {
         if let special = CGKeyCode._special[Int(self)] { return special }
         
         let source = TISCopyCurrentASCIICapableKeyboardLayoutInputSource().takeUnretainedValue()
@@ -392,7 +392,7 @@ public extension CGKeyCode {
 public extension CGEventFlags {
     
     /// The human-readable representation of the event modifier flags.
-    public var characters: String {
+    var characters: String {
         var string = ""
         if self.contains(.maskAlphaShift) { string.append("⇪") }
         if self.contains(.maskHelp) { string.append("?⃝") }
@@ -406,7 +406,7 @@ public extension CGEventFlags {
 public extension NSEvent.ModifierFlags {
     
     /// The human-readable representation of the event modifier flags.
-    public var characters: String {
+    var characters: String {
         return CGEventFlags(self).characters
     }
 }

--- a/CGSKeyboardShortcut.swift
+++ b/CGSKeyboardShortcut.swift
@@ -245,8 +245,9 @@ public final class CGSKeyboardShortcut: Hashable {
     //
     
     
-    public var hashValue: Int {
-        return ObjectIdentifier(self).hashValue
+    public func hash(into hasher: inout Hasher) {
+        // Unfortunately, automatic generation of hashing functions is not available for classes
+        hasher.combine(ObjectIdentifier(self))
     }
     
     public static func ==(lhs: CGSKeyboardShortcut, rhs: CGSKeyboardShortcut) -> Bool {

--- a/KeyboardShortcutView.swift
+++ b/KeyboardShortcutView.swift
@@ -491,7 +491,7 @@ open class KeyboardShortcutView: NSControl, NSSecureCoding, NSAccessibilityButto
         // NSLayerContentsFacet and CoreUI to optimize this, but it's a non-issue.
         var b = self.bounds.size; b.height = 22
         let img = NSImage(size: b, flipped: false) { r in
-            self.effectiveAppearance.using {
+            self.effectiveAppearance.performAsCurrentDrawingAppearance {
                 KeyboardShortcutView.stampCell.drawBezel(withFrame: r, in: self)
             }
             return true
@@ -895,19 +895,6 @@ public func representation(of dict: NSDictionary?) -> KeyboardShortcutView.Pair?
 //
 // MARK: - Cocoa Extensions
 //
-
-
-public extension NSAppearance {
-    
-    /// Convenience method to execute a block with a provided current appearance.
-    /// Identical to private `+[NSAppearance _performWithCurrentAppearance:usingBlock:]`
-    func using(_ handler: () -> ()) {
-        let x = NSAppearance.current
-        NSAppearance.current = self
-        handler()
-        NSAppearance.current = x
-    }
-}
 
 public extension UndoManager {
     

--- a/KeyboardShortcutView.swift
+++ b/KeyboardShortcutView.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import AppKit
 
 
 //
@@ -9,7 +10,7 @@ import Cocoa
 /// The protocol that `delegate`s of a `KeyboardShortcutView` must conform to.
 /// If the `KeyboardShortcutView` lacks a delegate, but has a `target`, that conforms
 /// to this protocol, it will be consulted instead.
-public protocol KeyboardShortcutViewDelegate: class {
+public protocol KeyboardShortcutViewDelegate: AnyObject {
     
     /// Return `true` to allow beginning the recording of user input for a shortcut.
     func keyboardShortcutViewShouldBeginRecording(_ keyboardShortcutView: KeyboardShortcutView) -> Bool
@@ -118,7 +119,7 @@ open class KeyboardShortcutView: NSControl, NSSecureCoding, NSAccessibilityButto
     
     
     /// Eh, why not. It's good practice.
-    open static var supportsSecureCoding: Bool {
+    public static var supportsSecureCoding: Bool {
         return true
     }
     
@@ -233,7 +234,7 @@ open class KeyboardShortcutView: NSControl, NSSecureCoding, NSAccessibilityButto
             
             // Send the control's action to its target or the first responder.
             _ = self.sendAction(self.action, to: self.target)
-            NSAccessibilityPostNotification(self, .valueChanged)
+            NSAccessibility.post(element: self, notification: .valueChanged)
             
             // Re-evaluate visual properties.
             self.needsDisplay = true
@@ -278,7 +279,7 @@ open class KeyboardShortcutView: NSControl, NSSecureCoding, NSAccessibilityButto
         let button = NSButton()
         button.wantsLayer = true
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.image = NSImage(named: .stopProgressTemplate)
+        button.image = NSImage(named: NSImage.stopProgressTemplateName)
         button.bezelStyle = .texturedRounded // for template image rendering
         button.setButtonType(.momentaryChange)
         button.isBordered = false
@@ -515,8 +516,8 @@ open class KeyboardShortcutView: NSControl, NSSecureCoding, NSAccessibilityButto
         // Update button visual state (and VoiceOver state).
         self.clearButton.isEnabled = self.isEnabled
         let canStop = self.isRecording || self.shortcut != nil
-        self.clearButton.image = NSImage(named: canStop ? .stopProgressFreestandingTemplate
-                                                        : .statusUnavailable)
+        self.clearButton.image = NSImage(named: canStop ? NSImage.stopProgressFreestandingTemplateName
+                                                        : NSImage.statusUnavailableName)
         self.clearButton.setAccessibilityLabel(canStop ? Localized.buttonRecordLabel
                                                        : Localized.buttonClearLabel)
     }
@@ -624,7 +625,7 @@ open class KeyboardShortcutView: NSControl, NSSecureCoding, NSAccessibilityButto
 
         // Clear the old shortcut and begin recording if the click was within us.
         let locationInView = self.convert(event.locationInWindow, from: nil)
-        if self.mouse(locationInView, in: self.bounds) && !self.isRecording {
+        if self.isMousePoint(locationInView, in: self.bounds) && !self.isRecording {
             self.inputModifiers = []
             _ = self.beginRecording()
         } else {
@@ -659,7 +660,9 @@ open class KeyboardShortcutView: NSControl, NSSecureCoding, NSAccessibilityButto
             self.endRecording()
             
             // Handle VoiceOver:
-            NSAccessibilityPostNotificationWithUserInfo(self, .announcementRequested, [
+            NSAccessibility.post(element: self, 
+                                 notification: .announcementRequested, 
+                                 userInfo: [
                 .announcement: Localized.voiceOverRecorded,
                 .priority: NSAccessibilityPriorityLevel.high
             ])
@@ -692,7 +695,9 @@ open class KeyboardShortcutView: NSControl, NSSecureCoding, NSAccessibilityButto
         self.isRecording = true
         
         // Present VoiceOver feedback.
-        NSAccessibilityPostNotificationWithUserInfo(self, .announcementRequested, [
+        NSAccessibility.post(element: self, 
+                             notification: .announcementRequested,
+                             userInfo: [
             .announcement: Localized.voiceOverBegin,
             .priority: NSAccessibilityPriorityLevel.high
         ])
@@ -731,7 +736,9 @@ open class KeyboardShortcutView: NSControl, NSSecureCoding, NSAccessibilityButto
             self.endRecording()
             
             // Handle VoiceOver:
-            NSAccessibilityPostNotificationWithUserInfo(self, .announcementRequested, [
+            NSAccessibility.post(element: self, 
+                                 notification: .announcementRequested,
+                                 userInfo: [
                 .announcement: Localized.voiceOverCleared,
                 .priority: NSAccessibilityPriorityLevel.high
             ])
@@ -832,7 +839,7 @@ open class KeyboardShortcutView: NSControl, NSSecureCoding, NSAccessibilityButto
     open override func accessibilityHelp() -> String? {
         return Localized.help
     }
-    open override func accessibilityRole() -> NSAccessibilityRole? {
+    open override func accessibilityRole() -> NSAccessibility.Role? {
         return .button
     }
     open override func accessibilityLabel() -> String? {
@@ -894,7 +901,7 @@ public extension NSAppearance {
     
     /// Convenience method to execute a block with a provided current appearance.
     /// Identical to private `+[NSAppearance _performWithCurrentAppearance:usingBlock:]`
-    public func using(_ handler: () -> ()) {
+    func using(_ handler: () -> ()) {
         let x = NSAppearance.current
         NSAppearance.current = self
         handler()
@@ -906,7 +913,7 @@ public extension UndoManager {
     
     /// Convenience method to register a target and set its action name simultaneously.
     @available(OSX 10.11, iOS 9.0, *)
-    public func registerUndo<TargetType: AnyObject>(withTarget target: TargetType, name: String, handler: @escaping (TargetType) -> Void) {
+    func registerUndo<TargetType: AnyObject>(withTarget target: TargetType, name: String, handler: @escaping (TargetType) -> Void) {
         self.registerUndo(withTarget: target, handler: handler)
         self.setActionName(name)
     }

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright © 2024 Aditya Vaidyam
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # CGSKeyboardShortcut
+
 A modern Swift take on MASShortcut, ShortcutRecorder, and the Carbon RegisterEventHotKey API.
+
+## AUTHORS
+
+Aditya Vaidyam: Original author
+
+## CONTRIBUTORS
+
+Andres Kievsky: Updated to work in Xcode 15.4 / Swift UI

--- a/SampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -1,0 +1,370 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		89F3F20F2C87D23A00489239 /* SampleAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F3F20E2C87D23A00489239 /* SampleAppApp.swift */; };
+		89F3F2112C87D23A00489239 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F3F2102C87D23A00489239 /* ContentView.swift */; };
+		89F3F2132C87D23C00489239 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 89F3F2122C87D23C00489239 /* Assets.xcassets */; };
+		89F3F2162C87D23C00489239 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 89F3F2152C87D23C00489239 /* Preview Assets.xcassets */; };
+		89F3F2212C87D27200489239 /* ShortcutRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F3F21D2C87D27200489239 /* ShortcutRecognizer.swift */; };
+		89F3F2222C87D27200489239 /* CGSKeyboardShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F3F21E2C87D27200489239 /* CGSKeyboardShortcut.swift */; };
+		89F3F2232C87D27200489239 /* KeyboardShortcutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F3F21F2C87D27200489239 /* KeyboardShortcutView.swift */; };
+		89F3F2242C87D27200489239 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 89F3F2202C87D27200489239 /* README.md */; };
+		89F3F2262C87D2A600489239 /* LICENSE.md in Resources */ = {isa = PBXBuildFile; fileRef = 89F3F2252C87D2A500489239 /* LICENSE.md */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		89F3F20B2C87D23A00489239 /* SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		89F3F20E2C87D23A00489239 /* SampleAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleAppApp.swift; sourceTree = "<group>"; };
+		89F3F2102C87D23A00489239 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		89F3F2122C87D23C00489239 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		89F3F2152C87D23C00489239 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		89F3F2172C87D23C00489239 /* SampleApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SampleApp.entitlements; sourceTree = "<group>"; };
+		89F3F21D2C87D27200489239 /* ShortcutRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ShortcutRecognizer.swift; path = ../ShortcutRecognizer.swift; sourceTree = "<group>"; };
+		89F3F21E2C87D27200489239 /* CGSKeyboardShortcut.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CGSKeyboardShortcut.swift; path = ../CGSKeyboardShortcut.swift; sourceTree = "<group>"; };
+		89F3F21F2C87D27200489239 /* KeyboardShortcutView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KeyboardShortcutView.swift; path = ../KeyboardShortcutView.swift; sourceTree = "<group>"; };
+		89F3F2202C87D27200489239 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		89F3F2252C87D2A500489239 /* LICENSE.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = LICENSE.md; path = ../LICENSE.md; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		89F3F2082C87D23A00489239 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		89F3F2022C87D23A00489239 = {
+			isa = PBXGroup;
+			children = (
+				89F3F2282C87D2BE00489239 /* Sources */,
+				89F3F20D2C87D23A00489239 /* SampleApp */,
+				89F3F20C2C87D23A00489239 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		89F3F20C2C87D23A00489239 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				89F3F20B2C87D23A00489239 /* SampleApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		89F3F20D2C87D23A00489239 /* SampleApp */ = {
+			isa = PBXGroup;
+			children = (
+				89F3F20E2C87D23A00489239 /* SampleAppApp.swift */,
+				89F3F2102C87D23A00489239 /* ContentView.swift */,
+				89F3F2122C87D23C00489239 /* Assets.xcassets */,
+				89F3F2172C87D23C00489239 /* SampleApp.entitlements */,
+				89F3F2142C87D23C00489239 /* Preview Content */,
+			);
+			path = SampleApp;
+			sourceTree = "<group>";
+		};
+		89F3F2142C87D23C00489239 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				89F3F2152C87D23C00489239 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		89F3F2282C87D2BE00489239 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				89F3F21E2C87D27200489239 /* CGSKeyboardShortcut.swift */,
+				89F3F21F2C87D27200489239 /* KeyboardShortcutView.swift */,
+				89F3F2252C87D2A500489239 /* LICENSE.md */,
+				89F3F2202C87D27200489239 /* README.md */,
+				89F3F21D2C87D27200489239 /* ShortcutRecognizer.swift */,
+			);
+			name = Sources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		89F3F20A2C87D23A00489239 /* SampleApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 89F3F21A2C87D23C00489239 /* Build configuration list for PBXNativeTarget "SampleApp" */;
+			buildPhases = (
+				89F3F2072C87D23A00489239 /* Sources */,
+				89F3F2082C87D23A00489239 /* Frameworks */,
+				89F3F2092C87D23A00489239 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SampleApp;
+			productName = SampleApp;
+			productReference = 89F3F20B2C87D23A00489239 /* SampleApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		89F3F2032C87D23A00489239 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
+				LastUpgradeCheck = 1540;
+				TargetAttributes = {
+					89F3F20A2C87D23A00489239 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+				};
+			};
+			buildConfigurationList = 89F3F2062C87D23A00489239 /* Build configuration list for PBXProject "SampleApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 89F3F2022C87D23A00489239;
+			productRefGroup = 89F3F20C2C87D23A00489239 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				89F3F20A2C87D23A00489239 /* SampleApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		89F3F2092C87D23A00489239 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				89F3F2262C87D2A600489239 /* LICENSE.md in Resources */,
+				89F3F2242C87D27200489239 /* README.md in Resources */,
+				89F3F2162C87D23C00489239 /* Preview Assets.xcassets in Resources */,
+				89F3F2132C87D23C00489239 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		89F3F2072C87D23A00489239 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				89F3F2112C87D23A00489239 /* ContentView.swift in Sources */,
+				89F3F2212C87D27200489239 /* ShortcutRecognizer.swift in Sources */,
+				89F3F2232C87D27200489239 /* KeyboardShortcutView.swift in Sources */,
+				89F3F2222C87D27200489239 /* CGSKeyboardShortcut.swift in Sources */,
+				89F3F20F2C87D23A00489239 /* SampleAppApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		89F3F2182C87D23C00489239 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		89F3F2192C87D23C00489239 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		89F3F21B2C87D23C00489239 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SampleApp/SampleApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"SampleApp/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.sample.SampleApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		89F3F21C2C87D23C00489239 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SampleApp/SampleApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"SampleApp/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.sample.SampleApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		89F3F2062C87D23A00489239 /* Build configuration list for PBXProject "SampleApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				89F3F2182C87D23C00489239 /* Debug */,
+				89F3F2192C87D23C00489239 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		89F3F21A2C87D23C00489239 /* Build configuration list for PBXNativeTarget "SampleApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				89F3F21B2C87D23C00489239 /* Debug */,
+				89F3F21C2C87D23C00489239 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 89F3F2032C87D23A00489239 /* Project object */;
+}

--- a/SampleApp/SampleApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SampleApp/SampleApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SampleApp/SampleApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SampleApp/SampleApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SampleApp/SampleApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SampleApp/SampleApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleApp/SampleApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SampleApp/SampleApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleApp/SampleApp/Assets.xcassets/Contents.json
+++ b/SampleApp/SampleApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleApp/SampleApp/ContentView.swift
+++ b/SampleApp/SampleApp/ContentView.swift
@@ -9,9 +9,11 @@ import SwiftUI
 
 struct SampleShortcutView: NSViewRepresentable {
     let placeholderString: String?
+    let delegate: KeyboardShortcutViewDelegate
     func makeNSView(context: Context) -> KeyboardShortcutView {
         let keyboardShortcutView = KeyboardShortcutView()
         keyboardShortcutView.placeholderString = placeholderString
+        keyboardShortcutView.delegate = delegate
         return keyboardShortcutView
     }
     
@@ -19,11 +21,30 @@ struct SampleShortcutView: NSViewRepresentable {
     }
 }
 
+class DelegateExample: KeyboardShortcutViewDelegate {
+    func keyboardShortcutViewShouldBeginRecording(_ keyboardShortcutView: KeyboardShortcutView) -> Bool {
+        true
+    }
+    
+    func keyboardShortcutView(_ keyboardShortcutView: KeyboardShortcutView, canRecordShortcut shortcut: KeyboardShortcutView.Pair) -> Bool {
+        true
+    }
+    
+    func keyboardShortcutViewDidEndRecording(_ keyboardShortcutView: KeyboardShortcutView) {
+        let text = keyboardShortcutView.shortcut.flatMap {
+            $0.modifierFlags.characters + $0.keyCode.characters
+        } ?? "nil"
+        print("Chosen shortcut was: \(text)")
+    }
+    
+}
+
 struct ContentView: View {
+    let delegateExample = DelegateExample()
     var body: some View {
         VStack {
             Text("Enter your shortcut:")
-            SampleShortcutView(placeholderString: "Shortcut")
+            SampleShortcutView(placeholderString: "Shortcut", delegate: delegateExample)
                 .frame(width: 100, height: 50)
                 .padding(.all, 20)
         }

--- a/SampleApp/SampleApp/ContentView.swift
+++ b/SampleApp/SampleApp/ContentView.swift
@@ -1,0 +1,36 @@
+//
+//  ContentView.swift
+//  SampleApp
+//
+//  Created by Andres Kievsky on 4/9/2024.
+//
+
+import SwiftUI
+
+struct SampleShortcutView: NSViewRepresentable {
+    let placeholderString: String?
+    func makeNSView(context: Context) -> KeyboardShortcutView {
+        let keyboardShortcutView = KeyboardShortcutView()
+        keyboardShortcutView.placeholderString = placeholderString
+        return keyboardShortcutView
+    }
+    
+    func updateNSView(_ ksv: KeyboardShortcutView, context: Context) {
+    }
+}
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Text("Enter your shortcut:")
+            SampleShortcutView(placeholderString: "Shortcut")
+                .frame(width: 100, height: 50)
+                .padding(.all, 20)
+        }
+        .padding(.all, 20)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/SampleApp/SampleApp/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/SampleApp/SampleApp/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SampleApp/SampleApp/SampleApp.entitlements
+++ b/SampleApp/SampleApp/SampleApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+</dict>
+</plist>

--- a/SampleApp/SampleApp/SampleAppApp.swift
+++ b/SampleApp/SampleApp/SampleAppApp.swift
@@ -1,0 +1,18 @@
+//
+//  SampleAppApp.swift
+//  SampleApp
+//
+//  Created by Andres Kievsky on 4/9/2024.
+//
+
+import SwiftUI
+
+@main
+struct SampleAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .windowResizability(.contentSize)
+    }
+}

--- a/ShortcutRecognizer.swift
+++ b/ShortcutRecognizer.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Defines a shortcut recognition mechanism that operates globally.
 /// It executes a subclass-defined action upon its activation.
 /// Think, similar to `NSGestureRecognizer`, but not `NSWindow` or `NSApp`-bound.
-public protocol ShortcutRecognizer: class {
+public protocol ShortcutRecognizer: AnyObject {
     
     /// Invoke this when the shortcut key is pressed.
     func keyDown()
@@ -94,7 +94,7 @@ public final class TapHoldShortcutRecognizer: ShortcutRecognizer {
 public extension ShortcutRecognizer {
     
     /// Bind a recognizer to a shortcut. Retain the returned object to ensure the binding.
-    public func bind(to shortcut: CGSKeyboardShortcut) -> Any {
+    func bind(to shortcut: CGSKeyboardShortcut) -> Any {
         let x = NotificationCenter.default.addObserver(forName: CGSKeyboardShortcut.pressedNotification, object: shortcut, queue: nil) { _ in
             self.keyDown()
         }


### PR DESCRIPTION
Thank you for taking the time to review this PR. All input is appreciated.

In this PR you will find:

- Update code to work in Xcode 15.4
  - Rationale: 'as minimal a change as we can make'
  - Update deprecated uses of 'open', add new hash implementation and other minor updates for Swift
  - Update to use some of the needed changes in NSImage names
  - Use performAsCurrentDrawingAppearance() as NSAppearance.current is deprecated
- Add license file
- Add a SwiftUI example project
  - Including a simple delegate
  - Include .gitignore

Screenshot in Xcode Preview:

<img width="405" alt="Screenshot 2024-09-04 at 11 02 23 AM" src="https://github.com/user-attachments/assets/931b2bc8-23c7-4064-96c1-fd06633af43f">

Running:

<img width="382" alt="Screenshot 2024-09-04 at 11 42 11 AM" src="https://github.com/user-attachments/assets/d9704a73-216c-46c5-a7c1-baf0a0810f59">
